### PR TITLE
feat: refactor logging to use structured slog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ export PORT ?= 8080
 export ORIGIN_URL ?= https://dummyjson.com
 export REDIS_ADDR ?= localhost:6379
 export CACHE_EXPIRES ?= 10m
+export LOG_LEVEL ?= INFO
 
 # Docker parameters
 DOCKER_COMPOSE_FILE=docker-compose.yml

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -12,43 +10,50 @@ import (
 
 	"github.com/TonyGLL/caching-proxy-server/internal"
 	"github.com/TonyGLL/caching-proxy-server/pkg/config"
+	"github.com/TonyGLL/caching-proxy-server/pkg/logger"
 )
 
 func main() {
 	// Load configuration from environment variables
 	cfg := config.Load()
 
+	// Initialize logger
+	log := logger.New(cfg.LogLevel)
+
 	// Initialize Redis client
 	redisClient, err := internal.NewRedisClient(cfg.RedisAddr)
 	if err != nil {
-		log.Fatalf("Failed to connect to Redis: %v", err)
+		log.Error("Failed to connect to Redis", "error", err)
+		os.Exit(1)
 	}
 	defer redisClient.Close()
 
 	// Create a new server
-	server := internal.NewServer(cfg, redisClient)
+	server := internal.NewServer(cfg, redisClient, log)
 
 	// Set up graceful shutdown
 	go func() {
 		if err := server.Start(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Could not start server: %v", err)
+			log.Error("Could not start server", "error", err)
+			os.Exit(1)
 		}
 	}()
 
-	fmt.Printf("Server started on port %d, proxying to %s\n", cfg.Port, cfg.OriginURL)
+	log.Info("Server started", "port", cfg.Port, "proxy_to", cfg.OriginURL)
 
 	// Wait for interrupt signal to gracefully shut down the server
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
-	fmt.Println("Shutting down server...")
+	log.Info("Shutting down server...")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	if err := server.Shutdown(ctx); err != nil {
-		log.Fatalf("Server shutdown failed: %v", err)
+		log.Error("Server shutdown failed", "error", err)
+		os.Exit(1)
 	}
 
-	fmt.Println("Server exited gracefully")
+	log.Info("Server exited gracefully")
 }

--- a/internal/proxy_test.go
+++ b/internal/proxy_test.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +21,8 @@ func TestProxy_CacheHit(t *testing.T) {
 		OriginURL:    "http://dummy-origin.com",
 		CacheExpires: 10 * time.Minute,
 	}
-	proxy, err := NewProxy(cfg, db)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	proxy, err := NewProxy(cfg, db, log)
 	require.NoError(t, err)
 
 	// Mock Redis GET
@@ -57,7 +59,8 @@ func TestProxy_CacheMiss(t *testing.T) {
 		OriginURL:    originServer.URL,
 		CacheExpires: 10 * time.Minute,
 	}
-	proxy, err := NewProxy(cfg, db)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	proxy, err := NewProxy(cfg, db, log)
 	require.NoError(t, err)
 
 	// Mock Redis GET (miss) and SET

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	OriginURL    string
 	RedisAddr    string
 	CacheExpires time.Duration
+	LogLevel     string
 }
 
 // Load loads the configuration from environment variables
@@ -27,6 +28,7 @@ func Load() *Config {
 		OriginURL:    getEnv("ORIGIN_URL", "https://dummyjson.com"),
 		RedisAddr:    getEnv("REDIS_ADDR", "localhost:6379"),
 		CacheExpires: getDurationEnv("CACHE_EXPIRES", 10*time.Minute),
+		LogLevel:     getEnv("LOG_LEVEL", "INFO"),
 	}
 }
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,33 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// New initializes and returns a new slog.Logger.
+// The log level is determined by the `LOG_LEVEL` environment variable.
+func New(logLevelStr string) *slog.Logger {
+	var level slog.Level
+
+	switch strings.ToUpper(logLevelStr) {
+	case "DEBUG":
+		level = slog.LevelDebug
+	case "INFO":
+		level = slog.LevelInfo
+	case "WARN":
+		level = slog.LevelWarn
+	case "ERROR":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo // Default level
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+
+	handler := slog.NewJSONHandler(os.Stdout, opts)
+	return slog.New(handler)
+}


### PR DESCRIPTION
Refactored the entire application to use the standard library's `log/slog` package for structured, leveled logging in JSON format.

Key changes:
- Created a new `pkg/logger` for centralized logger initialization.
- Added a `LOG_LEVEL` environment variable to `pkg/config` and `Makefile` for configurable log verbosity.
- Injected the logger dependency from `main` into the `Server` and `Proxy` components.
- Replaced all `log.Printf`, `log.Fatalf`, and `fmt.Println` calls with structured logging calls (e.g., `slog.Info`, `slog.Error`).
- Added contextual attributes (method, URL, cache_status) to logs in the proxy handler to improve observability.
- Updated tests to pass a mock logger, ensuring they remain silent and focused.

This change significantly improves the project's observability and brings it in line with modern best practices for production-grade services.